### PR TITLE
Revert to Spring Boot 2.2.6.RELEASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ Run the sample from the command line, providing the following properties
 * `spanner.instance`
 * `spanner.database`
 * `gcp.project`
+* `gcp.service_account_key_json_file`
 
 ```
-./gradlew bootRun -Dspring-boot.run.jvmArguments="-Dspanner.instance=[SPANNER-INSTANCE] -Dspanner.database=[SPANNER-DATABASE] -Dgcp.project=GCP-PROJECT"
+./gradlew bootRun -Dspring-boot.run.jvmArguments="-Dspanner.instance={SPANNER-INSTANCE} -Dspanner.database={SPANNER-DATABASE} -Dgcp.project={GCP-PROJECT} -Dgcp.service_account_key_json_file={PATH-TO-ACCOUNT-KEY-JSON-FILE}"
 ```
 
 Visit http://localhost:8080/index.html in your favorite browser.
@@ -80,14 +81,34 @@ gcloud spanner databases create library --instance={name}
 
 > A single service instance may support multiple databases. In this case we're creating a database named `library`.
 
-Push the app
+Push the app (but don't start it up)
 
 ```
-cf push
+cf push --no-start
 ```
 > The supplied `manifest.yml` sets the required environment variables.
 
-> Java Config via [java-cfenv](https://github.com/pivotal-cf/java-cfenv) takes care to auto-fetch Google Spanner instance credentials at startup which are used to setup a connection and support on-demand database transactions.
+> Java Config via [java-cfenv](https://github.com/pivotal-cf/java-cfenv) will take care to auto-fetch Google Spanner instance credentials at startup which are used to setup a connection and support on-demand database transactions.
+
+Bind the Google Spanner service instance to the app
+
+```
+cf bind-service spring-books spanner-sandbox-instance
+```
+
+Set an environment variable
+
+```
+cf set-env spring-books GCP_SERVICE_ACCOUNT_KEY_JSON '{key-file-contents}'
+```
+
+> We need to set an environment variable that contains the content of the service account JSON key file in order to authenticate requests from the application to the Google Spanner instance. Replace `{key-file-contents}` above with an actual service account key in JSON format.
+
+Start the app
+
+```
+cf start spring-books
+```
 
 Visit the route for the app you just pushed in your favorite browser.
 

--- a/README.md
+++ b/README.md
@@ -121,3 +121,11 @@ Try the different actions available:
 * listing books
 * adding a new book
 * searching for a book by its ID
+
+## Teardown
+
+```
+cf unbind-service spring-books spanner-sandbox-instance
+cf delete-service spanner-sandbox-instance -f
+cf delete spring-books -r -f
+```

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ dependencies {
 	//implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
     implementation 'org.springframework.boot.experimental:spring-boot-starter-data-r2dbc:0.1.0.M3'
 	implementation 'com.google.cloud:cloud-spanner-spring-data-r2dbc:0.2.0'
+    implementation 'org.springframework.boot:spring-boot-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'io.pivotal.cfenv:java-cfenv-boot:2.1.2.RELEASE'
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.3.0.M4'
+    id 'org.springframework.boot' version '2.2.6.RELEASE'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
     id 'com.github.ben-manes.versions' version '0.28.0'
 	id 'java'
@@ -72,13 +72,10 @@ jacocoTestReport {
 	}
 }
 
-ext {
-    set('spring-data-releasetrain.version', 'Neumann-RC1')
-}
-
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-configuration-processor'
-	implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
+	//implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
+    implementation 'org.springframework.boot.experimental:spring-boot-starter-data-r2dbc:0.1.0.M3'
 	implementation 'com.google.cloud:cloud-spanner-spring-data-r2dbc:0.2.0'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'io.pivotal.cfenv:java-cfenv-boot:2.1.2.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.2.6.RELEASE'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
     id 'com.github.ben-manes.versions' version '0.28.0'
+    id 'io.franzbecker.gradle-lombok' version '3.3.0'
 	id 'java'
     id 'jacoco'
 	id 'maven-publish'
@@ -73,6 +74,8 @@ jacocoTestReport {
 }
 
 dependencies {
+    annotationProcessor('org.projectlombok:lombok')
+    implementation('org.projectlombok:lombok')
 	implementation 'org.springframework.boot:spring-boot-configuration-processor'
 	//implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
     implementation 'org.springframework.boot.experimental:spring-boot-starter-data-r2dbc:0.1.0.M3'
@@ -133,7 +136,23 @@ publishing {
     }
 }
 
+import io.franzbecker.gradle.lombok.task.DelombokTask
+
+task delombok(type: DelombokTask, dependsOn: compileJava) {
+    ext.outputDir = file("$buildDir/delombok")
+    outputs.dir(outputDir)
+    sourceSets.main.java.srcDirs.each {
+        inputs.dir(it)
+        args(it, "-d", outputDir)
+    }
+    doFirst {
+        outputDir.deleteDir()
+    }
+}
+
 javadoc {
+    dependsOn delombok
+    source = delombok.outputDir
     failOnError = false
     if(JavaVersion.current().isJava9Compatible()) {
         options.addBooleanOption('html5', true)

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,3 +6,4 @@ applications:
   env:
     JAVA_OPTS: -Djava.security.egd=file:///dev/urandom
     SPRING_PROFILES_ACTIVE: cloud
+    BP_AUTO_RECONFIGURATION_ENABLED: false

--- a/src/main/java/io/pivotal/cfapp/books/springbooks/AppInit.java
+++ b/src/main/java/io/pivotal/cfapp/books/springbooks/AppInit.java
@@ -9,8 +9,6 @@ import static org.springframework.web.reactive.function.server.RouterFunctions.r
 
 import java.net.URI;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
@@ -32,6 +30,7 @@ import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.Option;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Driver application showing Cloud Spanner R2DBC use with Spring Data.
@@ -39,9 +38,8 @@ import io.r2dbc.spi.Option;
 @SpringBootApplication
 @EnableR2dbcRepositories
 @ConfigurationPropertiesScan
+@Slf4j
 public class AppInit {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(AppInit.class);
 
   private static final String SPANNER_INSTANCE = System.getProperty("spanner.instance");
 
@@ -80,6 +78,7 @@ public class AppInit {
 
     @Bean
     ConnectionFactory spannerConnectionFactory(@Autowired SpannerSettings settings) {
+      log.trace("Spanner settings are " + settings.toString());
       ConnectionFactory connectionFactory = ConnectionFactories.get(ConnectionFactoryOptions.builder()
         .option(Option.valueOf("project"), settings.getProject())
         .option(DRIVER, DRIVER_NAME)
@@ -94,7 +93,7 @@ public class AppInit {
 
   @EventListener(ApplicationReadyEvent.class)
   public void setUpData() {
-    LOGGER.info("Setting up test table BOOK...");
+    log.trace("Setting up test table BOOK...");
     try {
       r2dbcClient.execute("CREATE TABLE BOOK ("
           + "  ID STRING(36) NOT NULL,"
@@ -102,24 +101,24 @@ public class AppInit {
           + ") PRIMARY KEY (ID)")
           .fetch().rowsUpdated().block();
     } catch (Exception e) {
-      LOGGER.info("Failed to set up test table BOOK", e);
+      log.trace("Failed to set up test table BOOK", e);
       return;
     }
-    LOGGER.info("Finished setting up test table BOOK");
+    log.trace("Finished setting up test table BOOK");
   }
 
   @EventListener({ContextClosedEvent.class})
   public void tearDownData() {
-    LOGGER.info("Deleting test table BOOK...");
+    log.trace("Deleting test table BOOK...");
     try {
       r2dbcClient.execute("DROP TABLE BOOK")
           .fetch().rowsUpdated().block();
     } catch (Exception e) {
-      LOGGER.info("Failed to delete test table BOOK", e);
+      log.trace("Failed to delete test table BOOK", e);
       return;
     }
 
-    LOGGER.info("Finished deleting test table BOOK.");
+    log.trace("Finished deleting test table BOOK");
   }
 
 

--- a/src/main/java/io/pivotal/cfapp/books/springbooks/AppInit.java
+++ b/src/main/java/io/pivotal/cfapp/books/springbooks/AppInit.java
@@ -59,19 +59,19 @@ public class AppInit {
   @Profile("!cloud")
   public static class DefaultConfig {
 
-	@Bean
-	ConnectionFactory spannerConnectionFactory(@Value("${spanner.database}") String database) {
-		Assert.notNull(INSTANCE, "Please provide spanner.instance property");
-		Assert.notNull(GCP_PROJECT, "Please provide gcp.project property");
-		ConnectionFactory connectionFactory = ConnectionFactories.get(ConnectionFactoryOptions.builder()
-			.option(Option.valueOf("project"), GCP_PROJECT)
-			.option(DRIVER, DRIVER_NAME)
-			.option(INSTANCE, SPANNER_INSTANCE)
-			.option(DATABASE, database)
-			.build());
+    @Bean
+    ConnectionFactory spannerConnectionFactory(@Value("${spanner.database}") String database) {
+      Assert.notNull(INSTANCE, "Please provide spanner.instance property");
+      Assert.notNull(GCP_PROJECT, "Please provide gcp.project property");
+      ConnectionFactory connectionFactory = ConnectionFactories.get(ConnectionFactoryOptions.builder()
+        .option(Option.valueOf("project"), GCP_PROJECT)
+        .option(DRIVER, DRIVER_NAME)
+        .option(INSTANCE, SPANNER_INSTANCE)
+        .option(DATABASE, database)
+        .build());
 
-		return connectionFactory;
-	}
+      return connectionFactory;
+    }
 
   }
 
@@ -79,21 +79,25 @@ public class AppInit {
   @Profile("cloud")
   public static class CloudConfig {
 
-	@Bean
-	ConnectionFactory spannerConnectionFactory(@Value("${spanner.database}") String database) {
-		CfEnv cfEnv = new CfEnv();
-		List<CfService> spannerServiceInstances = cfEnv.findServicesByTag("gcp","spanner");
-		Assert.isTrue(spannerServiceInstances.size() == 1, "Only one spanner.instance may exist in the same space");
-		CfService spannerServiceInstance = spannerServiceInstances.get(0);
-		ConnectionFactory connectionFactory = ConnectionFactories.get(ConnectionFactoryOptions.builder()
-			.option(Option.valueOf("project"), spannerServiceInstance.getString("ProjectId"))
-			.option(DRIVER, DRIVER_NAME)
-			.option(INSTANCE, spannerServiceInstance.getString("instance_id"))
-			.option(DATABASE, database)
-			.build());
+    @Bean
+    public CfEnv cfEnv() {
+      return new CfEnv();
+    }
 
-		return connectionFactory;
-	}
+    @Bean
+    ConnectionFactory spannerConnectionFactory(@Value("${spanner.database}") String database) {
+      List<CfService> spannerServiceInstances = cfEnv().findServicesByTag("gcp", "spanner");
+      Assert.isTrue(spannerServiceInstances.size() == 1, "Only one spanner.instance may exist in the same space");
+      CfService spannerServiceInstance = spannerServiceInstances.get(0);
+      ConnectionFactory connectionFactory = ConnectionFactories.get(ConnectionFactoryOptions.builder()
+        .option(Option.valueOf("project"), spannerServiceInstance.getString("ProjectId"))
+        .option(DRIVER, DRIVER_NAME)
+        .option(INSTANCE, spannerServiceInstance.getString("instance_id"))
+        .option(DATABASE, database)
+        .build());
+
+      return connectionFactory;
+    }
 
   }
 

--- a/src/main/java/io/pivotal/cfapp/books/springbooks/SpannerCfEnvProcessor.java
+++ b/src/main/java/io/pivotal/cfapp/books/springbooks/SpannerCfEnvProcessor.java
@@ -6,15 +6,21 @@ import io.pivotal.cfenv.core.CfCredentials;
 import io.pivotal.cfenv.core.CfService;
 import io.pivotal.cfenv.spring.boot.CfEnvProcessor;
 import io.pivotal.cfenv.spring.boot.CfEnvProcessorProperties;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class SpannerCfEnvProcessor implements CfEnvProcessor {
 
+    private static final String SERVICE_NAME = "google-spanner-instance";
 
     @Override
     public boolean accept(CfService service) {
-        return
+        boolean found =
             service.existsByTagIgnoreCase("gcp", "spanner") ||
             service.existsByLabelStartsWith("google-spanner");
+        if (found)
+            log.trace("Spanner instance with name " + service.getName() + " found.");
+        return found;
     }
 
     @Override
@@ -28,7 +34,7 @@ public class SpannerCfEnvProcessor implements CfEnvProcessor {
         return
             CfEnvProcessorProperties
                 .builder()
-			        .serviceName("google-spanner-instance")
+			        .serviceName(SERVICE_NAME)
 			        .build();
     }
 

--- a/src/main/java/io/pivotal/cfapp/books/springbooks/SpannerCfEnvProcessor.java
+++ b/src/main/java/io/pivotal/cfapp/books/springbooks/SpannerCfEnvProcessor.java
@@ -1,0 +1,39 @@
+package io.pivotal.cfapp.books.springbooks;
+
+import java.util.Map;
+
+import io.pivotal.cfenv.core.CfCredentials;
+import io.pivotal.cfenv.core.CfService;
+import io.pivotal.cfenv.spring.boot.CfEnvProcessor;
+import io.pivotal.cfenv.spring.boot.CfEnvProcessorProperties;
+
+public class SpannerCfEnvProcessor implements CfEnvProcessor {
+
+
+    @Override
+    public boolean accept(CfService service) {
+        return
+            service.existsByTagIgnoreCase("gcp", "spanner") ||
+            service.existsByLabelStartsWith("google-spanner");
+    }
+
+    @Override
+    public void process(CfCredentials cfCredentials, Map<String, Object> properties) {
+        addPropertyValue("spanner.instance", cfCredentials.getString("instance_id"), properties);
+        addPropertyValue("spanner.project", cfCredentials.getString("ProjectId"), properties);
+    }
+
+    @Override
+    public CfEnvProcessorProperties getProperties() {
+        return
+            CfEnvProcessorProperties
+                .builder()
+			        .serviceName("google-spanner-instance")
+			        .build();
+    }
+
+    private static void addPropertyValue(String propertyName, Object propertyValue, Map<String, Object> properties) {
+        properties.put(propertyName, propertyValue);
+    }
+
+}

--- a/src/main/java/io/pivotal/cfapp/books/springbooks/SpannerCfEnvProcessor.java
+++ b/src/main/java/io/pivotal/cfapp/books/springbooks/SpannerCfEnvProcessor.java
@@ -16,7 +16,7 @@ public class SpannerCfEnvProcessor implements CfEnvProcessor {
     @Override
     public boolean accept(CfService service) {
         boolean found =
-            service.existsByTagIgnoreCase("gcp", "spanner") ||
+            service.existsByTagIgnoreCase("spanner") ||
             service.existsByLabelStartsWith("google-spanner");
         if (found)
             log.trace("Spanner instance with name " + service.getName() + " found.");
@@ -27,6 +27,7 @@ public class SpannerCfEnvProcessor implements CfEnvProcessor {
     public void process(CfCredentials cfCredentials, Map<String, Object> properties) {
         addPropertyValue("spanner.instance", cfCredentials.getString("instance_id"), properties);
         addPropertyValue("spanner.project", cfCredentials.getString("ProjectId"), properties);
+        addOrUpdatePropertyValue("gcp.service_account_key_json", "GCP_SERVICE_ACCOUNT_KEY_JSON", cfCredentials, properties);
     }
 
     @Override
@@ -40,6 +41,13 @@ public class SpannerCfEnvProcessor implements CfEnvProcessor {
 
     private static void addPropertyValue(String propertyName, Object propertyValue, Map<String, Object> properties) {
         properties.put(propertyName, propertyValue);
+    }
+
+    private static void addOrUpdatePropertyValue(String propertyName, String credentialName, CfCredentials cfCredentials, Map<String, Object> properties) {
+        Object credential = cfCredentials.getMap().get(credentialName);
+        if (credential != null) {
+            properties.put(propertyName, credential);
+        }
     }
 
 }

--- a/src/main/java/io/pivotal/cfapp/books/springbooks/SpannerSettings.java
+++ b/src/main/java/io/pivotal/cfapp/books/springbooks/SpannerSettings.java
@@ -29,13 +29,4 @@ public class SpannerSettings {
         return this.project;
     }
 
-    @Override
-    public String toString() {
-        return "{" +
-            " database='" + database + "'" +
-            ", instance='" + instance + "'" +
-            ", project='" + project + "'" +
-            "}";
-    }
-
 }

--- a/src/main/java/io/pivotal/cfapp/books/springbooks/SpannerSettings.java
+++ b/src/main/java/io/pivotal/cfapp/books/springbooks/SpannerSettings.java
@@ -1,0 +1,35 @@
+package io.pivotal.cfapp.books.springbooks;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "spanner")
+public class SpannerSettings {
+
+    private final String database;
+    private final String instance;
+    private final String project;
+
+    public SpannerSettings(String database, String instance, String project) {
+        this.database = database;
+        this.instance = instance;
+        this.project = project;
+    }
+
+
+    public String getDatabase() {
+        return this.database;
+    }
+
+
+    public String getInstance() {
+        return this.instance;
+    }
+
+
+    public String getProject() {
+        return this.project;
+    }
+
+}

--- a/src/main/java/io/pivotal/cfapp/books/springbooks/SpannerSettings.java
+++ b/src/main/java/io/pivotal/cfapp/books/springbooks/SpannerSettings.java
@@ -17,19 +17,25 @@ public class SpannerSettings {
         this.project = project;
     }
 
-
     public String getDatabase() {
         return this.database;
     }
-
 
     public String getInstance() {
         return this.instance;
     }
 
-
     public String getProject() {
         return this.project;
+    }
+
+    @Override
+    public String toString() {
+        return "{" +
+            " database='" + database + "'" +
+            ", instance='" + instance + "'" +
+            ", project='" + project + "'" +
+            "}";
     }
 
 }

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+io.pivotal.cfenv.spring.boot.CfEnvProcessor=io.pivotal.cfapp.books.springbooks.SpannerCfEnvProcessor

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-spanner.databse=library
+spanner.database=library

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,0 @@
-spanner.database=library
-
-logging.level.root=WARN
-logging.level.io.pivotal.cfapp=TRACE
-logging.level.io.pivotal.cfenv.spring.boot=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spanner.database=library
+
+logging.level.root=WARN
+logging.level.io.pivotal.cfapp=TRACE
+logging.level.io.pivotal.cfenv.spring.boot=DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+spanner:
+  database: library
+
+logging:
+  level:
+    root: WARN
+    io.pivotal.cfapp: TRACE
+    io.pivotal.cfenv.spring.boot: DEBUG
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: beans,configprops,env,info,health,metrics,loggers
+
+---
+spring:
+  profiles: cloud
+
+  main:
+    cloud-platform: CLOUD_FOUNDRY


### PR DESCRIPTION
Spring Boot 2.3.0.M4 appears to be to bleeding edge as `spring-boot-cnb` builds fail with 

```
ERROR: failed to export: creating app layers: exporting layer 'app': open /workspace/BOOT-INF/classpath.idx: permission denied
```

